### PR TITLE
Fixed makeDialogTextWithSpeaker and addGraf

### DIFF
--- a/NN_chatCmd.js
+++ b/NN_chatCmd.js
@@ -85,7 +85,7 @@ nerthus.chatCmd.map["dial666"] = function(ch)
 nerthus.chatCmd.makeDialogTextWithSpeaker = function(str)
 {
    str = str.split(" ").slice(1).join(" ").split(",");
-   return "&laquo;"+str[0]+"&raquo; " + str.slice(1).join(",");
+   return "«"+str[0]+"» " + str.slice(1).join(",");
 }
 
 nerthus.chatCmd.map["sys"] = function(ch)
@@ -123,7 +123,7 @@ nerthus.chatCmd.map["addGraf"] = function(ch)
     {  //wyśrodkowanie w osi x i wyrównanie do stóp w osi y
         var _x = 32 * x + 16 - Math.floor($(this).width() / 2);
         var _y = 32 * y + 32 - $(this).height();
-        $(this).css({top:"" + _y + "px", left: "" + _x + "px"}).css("z-index", map.y+1);
+        $(this).css({top:"" + _y + "px", left: "" + _x + "px"}).css("z-index", y * 2 + 9);
     })
     if(isCol) g.npccol[ x + 256 * y] = true;
     return true;

--- a/NN_start.js
+++ b/NN_start.js
@@ -1,6 +1,6 @@
 /**
     Start dodatku. Najpierw pobiera wersje dodatku, która jest rewizją z mastera, potem resztę plików dodatku w tej wersji.
-    Wersia jest w pliku version.json
+    Wersja jest w pliku version.json
     Jeżeli jest zdefiniowana zmienna localStorage.NerthusAddonDebug = true odpala debug moda i ciągnie świeże pliki bezpośrednio z master z pominięciem cdn
     Flaga localStorage.NerthusAddonDebug = true blokuje wczytywanie z localStorage
 **/


### PR DESCRIPTION
NN_chatCmd.js:

Changed characters in makeDialogTextWithSpeaker to "«" and "» " instead of  `&laquo;` and `&raquo; ` so it works in new margonem update.
Changed z-index of addGraf to make character stand before NPC if standing on same level and behind if standing higher. This also allows several NPCs to line one behind another.

NN_start.js:

Fixed typo in comments.