### PR TITLE
Change old extractUrlFromDecorator to new one

### DIFF
--- a/NN_chatCmd.js
+++ b/NN_chatCmd.js
@@ -12,7 +12,7 @@ nerthus.chatCmd.run = function(ch)
         var callback = this.fetch_callback(cmd,ch)
         if(callback)
         {
-            log("["+ch.k+"] " + ch.n + " -> " + ch.t) //gdze kto co
+            log("["+ch.k+"] " + ch.n + " -> " + ch.t) //gdzie kto co
             return callback(ch)
         }
     }

--- a/NN_chatCmd.js
+++ b/NN_chatCmd.js
@@ -131,11 +131,9 @@ nerthus.chatCmd.map["addGraf"] = function(ch)
 
 nerthus.chatCmd.extractUrlFromDecorator = function(text)
 {
-    if(text[0]=='<') //is text wrapped by html tag
-    {
-        var url = RegExp(/goToUrl\(\"(\S+)\"\)/).exec(text);
-        if(url) return "http://" + url[1];
-    }
+    let url = RegExp(/https\*Krzywi się\.\*(\S+)/).exec(text);
+    if(url)
+        return "https:/" + url[1];
     return text;
 }
 

--- a/NN_chatCmd.js
+++ b/NN_chatCmd.js
@@ -131,10 +131,15 @@ nerthus.chatCmd.map["addGraf"] = function(ch)
 
 nerthus.chatCmd.extractUrlFromDecorator = function(text)
 {
-    let url = RegExp(/https\*Krzywi się\.\*(\S+)/).exec(text);
+    let url = RegExp(/https\*Krzywi się\.\*(\S+)/).exec(text)
     if(url)
-        return "https:/" + url[1];
-    return text;
+        return "https:/" + url[1]
+    else {
+        let url = RegExp(/http\*Krzywi się\.\*(\S+)/).exec(text)
+        if(url)
+            return "http:/" + url[1]
+        return text
+    }
 }
 
 

--- a/NN_chatCmd.js
+++ b/NN_chatCmd.js
@@ -135,7 +135,7 @@ nerthus.chatCmd.extractUrlFromDecorator = function(text)
     if(url)
         return "https:/" + url[1]
     else {
-        let url = RegExp(/http\*Krzywi się\.\*(\S+)/).exec(text)
+        url = RegExp(/http\*Krzywi się\.\*(\S+)/).exec(text)
         if(url)
             return "http:/" + url[1]
         return text

--- a/NN_chatCmd.js
+++ b/NN_chatCmd.js
@@ -131,15 +131,10 @@ nerthus.chatCmd.map["addGraf"] = function(ch)
 
 nerthus.chatCmd.extractUrlFromDecorator = function(text)
 {
-    let url = RegExp(/https\*Krzywi się\.\*(\S+)/).exec(text)
+    let url = RegExp(/(https?)\*Krzywi się\.\*(\S+)/).exec(text)
     if(url)
-        return "https:/" + url[1]
-    else {
-        url = RegExp(/http\*Krzywi się\.\*(\S+)/).exec(text)
-        if(url)
-            return "http:/" + url[1]
-        return text
-    }
+        return url[1] + ":/" + url[2]
+    return text
 }
 
 

--- a/test/chatCmd_suite.js
+++ b/test/chatCmd_suite.js
@@ -25,7 +25,7 @@ test("dummy", function()
 })
 
 test("change https*Krzywi się.*/ to normal link", function() {
-    let buggedText = "https*Krzywi się.*/www.link.pl/images/image.gif",
-        fixedText = "https://www.link.pl/images/image.gif"
-    expect(nerthus.chatCmd.extractUrlFromDecorator(buggedText)).to.be(fixedText)
+    const buggedLink = "https*Krzywi się.*/www.link.pl/images/image.gif"
+    const fixedLink = "https://www.link.pl/images/image.gif"
+    expect(nerthus.chatCmd.extractUrlFromDecorator(buggedLink)).to.be(fixedLink)
 })

--- a/test/chatCmd_suite.js
+++ b/test/chatCmd_suite.js
@@ -24,7 +24,7 @@ test("dummy", function()
 {
 })
 
-test("zmiana https*Krzywi się.*/ na poprawny link", function() {
+test("change https*Krzywi się.*/ to normal link", function() {
     let buggedText = "https*Krzywi się.*/www.link.pl/images/image.gif",
         fixedText = "https://www.link.pl/images/image.gif"
     expect(nerthus.chatCmd.extractUrlFromDecorator(buggedText)).to.be(fixedText)

--- a/test/chatCmd_suite.js
+++ b/test/chatCmd_suite.js
@@ -24,3 +24,8 @@ test("dummy", function()
 {
 })
 
+test("zmiana https*Krzywi się.*/ na poprawny link", function() {
+    let buggedText = "https*Krzywi się.*/www.link.pl/images/image.gif",
+        fixedText = "https://www.link.pl/images/image.gif"
+    expect(nerthus.chatCmd.extractUrlFromDecorator(buggedText)).to.be(fixedText)
+})

--- a/test/chatCmd_suite.js
+++ b/test/chatCmd_suite.js
@@ -29,3 +29,9 @@ test("change https*Krzywi się.*/ to normal link", function() {
     const fixedLink = "https://www.link.pl/images/image.gif"
     expect(nerthus.chatCmd.extractUrlFromDecorator(buggedLink)).to.be(fixedLink)
 })
+
+test("change http*Krzywi się.*/ to normal link", function() {
+    const buggedLink = "http*Krzywi się.*/www.link.pl/images/image.gif"
+    const fixedLink = "http://www.link.pl/images/image.gif"
+    expect(nerthus.chatCmd.extractUrlFromDecorator(buggedLink)).to.be(fixedLink)
+})


### PR DESCRIPTION
Now links are handled diffrently in margonem and links in ch.t are always as plain text. However, there is a bug with `https://` that changes it to  `https*Krzywi się.*/`. New old extractUrlFromDecorator fixes it so that `*addgraf` and `*map` can now work with `https://`