### PR TITLE
Fix styles on SI after new game update

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,11 +47,11 @@
 /* Panel */
 #nerthus-panel {
     animation: fade 0.5s;
-    border-image: url(http://tempest.margonem.pl/img/gui/tmp/window-frame.png) 32 20 repeat;
+    border-image: url(https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Ftempest.margonem.pl%2Fimg%2Fgui%2Ftmp%2Fwindow-frame.png) 32 20 repeat; /* ../img/gui/tmp/window-frame.png */
     border-style: solid;
     border-width: 34px 13px 10px 13px;
     color: #000;
-    cursor: url(http://nerthus.margonem.pl/img/gui/cursor/1.png), url(http://nerthus.margonem.pl/img/gui/cursor/1.cur), auto;
+    cursor: url(../img/gui/cursor/1.png), url(../img/gui/cursor/1.cur), auto;
     left: calc(50% - 204px);
     pointer-events: auto;
     position: fixed;
@@ -63,7 +63,7 @@
 
 #nerthus-panel > .background {
     background-color: #f1deaa;
-    background-image: url(http://tempest.margonem.pl/img/gui/content-redleather.jpg);
+    background-image: url(https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Ftempest.margonem.pl%2Fimg%2Fgui%2Fcontent-redleather.jpg); /* ../img/gui/content-redleather.jpg */
 }
 
 /* Panel - nav */
@@ -77,7 +77,7 @@
 }
 
 #nerthus-panel .header-label {
-    background: url(http://tempest.margonem.pl/img/gui/dialogue/dialogi-naglowek.png);
+    background: url(https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Ftempest.margonem.pl%2Fimg%2Fgui%2Fdialogue%2Fdialogi-naglowek.png); /* ../img/gui/dialogue/dialogi-naglowek.png */
     display: inline-block;
     height: 28px;
     margin: 0 auto;
@@ -86,7 +86,7 @@
 
 #nerthus-panel .header-label > .right-decor,
 #nerthus-panel .header-label > .left-decor {
-    background: url(http://tempest.margonem.pl/img/gui/dialogue/dialogi.png) -38px -2px;
+    background: url(https://external-content.duckduckgo.com/iu/?u=http%3A%2F%2Ftempest.margonem.pl%2Fimg%2Fgui%2Fdialogue%2Fdialogi.png) -38px -2px; /* ../img/gui/dialogue/dialogi-naglowek.png */
     height: 28px;
     left: -52px;
     position: absolute;
@@ -111,30 +111,35 @@
 }
 
 #nerthus-panel > .close-decor {
-    background: url(http://tempest.margonem.pl/img/gui/buttony.png?v=5) -380px -55px;
-    height: 52px;
+    /* ../img/gui/buttony.png -380px -55px; */
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADMAAAAzCAMAAAANf8AYAAAC91BMVEUAAAAXFBIyLCEICgoJCgoNDw8ODAooIh8SEhEoHhgTFRYODQwdHBoTFBQTEQ8PDg0ICAYNDAsWGBUMCwsVEA07PT0NEBEUFxdCQUAeHBYLDQ4eHhoXFRIHCQgeHhonHhsICwwOEA9IRjZ4clQ/REYuMDIdHR09PD2usrN+fn9WW14RCwgICAcRDgwVFRRGS04JBgUlKCoZFhUaHR4EBgZAPSwcGxMICwtGQTAMDQ4oGxIpGxIDBgcICAhoHx86EhIpDQ0CAwOjp6sWExAtDg6hp6oxDw8LDAwZFBIICgsVEQ8SEA8VEA6lqa1lHh4aGxwQExQPERIbCQkGBwddHBwbGBYMDxAUEA2pr7APDg4KDQ6ora+kqKx4IyNaGhqorrGUmJwpLCxsHx9gHBwfGxgdGhhNFxcaFhUFBQWfo6eDiIpudXdcYWMmJydzISFXGRkVFxhIFhZEFRUWFRQaFRM+ExM2ERE0EBArDQ2eoKSZn6GXnJ+MkJJfZGdXYGJbXF1QVFVGTU9ESks7PT81NzgwMjMhJieAJCR1ISFxISFpHx8yHh5UGRkRFhdBFBQ4EREnDAwiCgrc2tjHxsWyt7y9vLqqpqSNmJydmZePlJZ7gIF1eXpiaWtKUlNFSEgtLi+iLi6eLCwgIyQcHyAWHR4pGBgTERATDQseCgoYCAjW2dnT0s/PzcrFxMS0srCnrK2kq6ydo6V+hIZ5fX9RW1xMVFdMTk9HR0k7Q0RAQEE4OTskKSobIyM9ISFvICAYGRpLFhYSFRY8ExMkCwsTBwbk4+LGz9LKy8q8w8SsvMG3vcDBvr60u76rs7eir7K9sbGxq6msqKako5+KlZh6iYyIgX91fH9seX6CeH1tb3FjbXFTW1xARUYsNDWSKipMJSUkGxlQGBgkGRZGFhYiFhZGFRUeFxIfCQny9vfp5+a3wMK5ubawtbWytLWwr62lp6esoaGln56LjIx1hIhzf4FmcndnZ2ZfMDBVLi6TKiqKJyc8EhI7EhJRH7WhAAAAPXRSTlMADwda/fxSJB0T/v3y38e/qHg38vHr6ufd3dXEnY1+QDoyGxL6+vry8PDv7+Ha19XHwbSvrp6MhnNuZVlKI0iQvwAABLRJREFUSMeV1HVsGlEcwHHq7dzd3d23A8oddxxQvFBoaQs16u7u7u7eubuvMnd3d3ffH3swkiUrJbvvJe+9P+6Tl/wuOZKOzEYOnDKExbK2lrCZMEO7MdxcrF2c3YJYLEPwivkYI1NToxVjLLTEaEbsxkgb1hs6jW5Hs7LRbrbuDrZWkY7hG1gGJPP5A+O8PCu3eDUMW7DYqJ+BxciW2M3ba6uC6LsDhZb/JOQm0q0NSKMSYq9XlNOLTjuUxuw52L/XrGTH0moxzodpGIIEpN6pr6urr6uvr/t+50c6hYpANGBAkDE3uSb6iufnj1e9Emo8t9ziG/MsmXRV6C+5D4dzIE3u4yNP5zj5yEVUVEWXaEyUZ1wyH+umUCRu3xa/PSZF2OrH40rsVLkZqRyOMkOeKk/1UWYoOXJ5QIjKjq0xzJUSJhwYKIWEGI8LHj4Pw3A2TUhJJ4vsRb5OyrQDB5yy7LPsU8m5QhoTmD8VnSo67e5RlcDHuYnJfK4fn2EFUQBx/Xr27iFf38d3z347dN+HTIGsYK3Rtmfy7j1+ssZqhUyMwzbA+Lr6v1tbmBmWl3ny8Lk2V3tgbBha87e+vUxkKdEKCA+iA+N6KHh/2bpCN7eTBSX7g/3VRj3rTlnMk8V7sFgwDRh//5/Ig7K169cfLmlGc/x9gaEB0zlzk2yP3ThTfc/DhzmoAD5f8PwlLAgJDrgPjGbWnRsqS6gUS+yACQhoQ1cHnltbUBwoQINzXIHRzLpzvcW8qHg2DZjg4Ny8e8XrSkoKCpuplMdqQ2PqNDPFsoQIzazbKGhm8boLLS0X1hRmohR/7aw7Nxqy5DVFaWadG4q+Ly571NHxqOzoeSQkQPesQX38ksTZNxm2wISgYZmXm5/m5z9tvrwfCaUAY6vTmER5qnjVsDswoShKzaciCJLX3o6iaAgw7m46jOneo7vw7AoXB/U9SFgYlYqiYdQwtcwCxsFFh1ne6u4RX37C2RYKFdkjVGoelapdcpyAsdX1TQ2me5fTHGvB3BBfToYyLV2pTEtLJ3M4HHJGVi5kBe7pnNmI3j2NO5iRkCDU1Z5DdhJxyGBxEolEWTn5UKQzMLozHOAIIcjq1QLBqlX57QKBQHNCEcgRzKCrBoRfg3R0LTyoa9NjQ1f/Kj3GJQhmStgMWLsxYBdnBpPNVv8Tu86idxJtU3nEWy8uBGEYJmU+wYRJVZsnmeoxyw4eq0xpul31an1sgxBjSVlPHsCqW2c29tRj+sQ57MNl2eJ91Vtfb23EpVJMek8qjn42VY8ZHhvRlK3gi2X8fbs8wqO7SQO5LZjfxTVD9Jgl3ps3bvIQ4oMGm7Q2bdvi5S32xvifjuww0mMMR/WouO7Xazw49uvJu70tvkGIx7z4MseQpK9xi4YuBER9GsTbm5RiuSviQ/+xpP9t9PBujTj3xibvviQCmfFVDZ6V3UmEWokrLtUQNBLZ3kuJBA0bS7kaY0zQcA/eKOURNLVYzPHavsRmkMiPO36zDzGzU5F05uIwEqF27mgsPTLYnJjZil9ZM3EsiVCOQq9jE/oRMw5YzalpZsRMkdQ7YrYhMXPCjRs1l0Qw5+SKEYTNjrilhE00BNbfoyPmnlcxJKgAAAAASUVORK5CYII=');
+    height: 51px;
     pointer-events: none;
     position: absolute;
     right: -15px;
-    top: -35px;
+    top: -34px;
     width: 51px;
 }
 
 #nerthus-panel .close-button {
-    background: url(http://tempest.margonem.pl/img/gui/buttony.png?v=5) -263px -79px;
+    /* ../img/gui/buttony.png -263px -79px; */
+    background-color: transparent;
+    background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAWCAMAAADzapwJAAAAmVBMVEUGBgYmJiZDQ0MbGxseHh4gICAqKioREREUFBRKSkojIyNBQUE5OTk8PDwxMTEuLi5HR0c2NjZNTU0YGBg+Pj7HxsWpp6VSUlIKCgrc2thoaGhlZWXm5OPPzcq9vLu4uLZeXl7S0c/BwL+ko5+bmZd9fX3Y1tTV1NDMyse/vbytra2vraqqqqmioqGem5iamJWGhYOEg4FYWFhz/846AAABJ0lEQVQY023QV3LFIAwFUIqETQfj7tdLet//4oLf2MlHcgeQ5sAHI6JL8ifckh5AdIdpHKdxmsbD4StQDj0hilZS6yArmZeuZWU5ksys05qxqqs6GRjTVSVUZiqZNdbUTIZQRxNNx26c1YV9dDF6s9cuSkZvbJxvjw3lnJ42T9SZhZ0T/rJtUjoNrRfOLuw9BXi7b5pNiyi8+WGBRdkOm31ZKCHiwkJQKMrn47ArCxTC/XLC3bZthwY59StTinS3PRfl+a7JrV8Z8fXxnRc9vzy8gFpZIRefqsxRHw4UXRgReeIAwFMCQLW+Bg6cI84FAMzMvbImY+JrRM1onjcYzYKUIW/J9DzjOE+wUC5f1FazfNTW2ijKzABFTv5GyuXWIRByJf/k+g025BKYzhUieAAAAABJRU5ErkJggg==');
+    background-position-y: -22px;
+    background-repeat: no-repeat;
     border: 0;
-    cursor: url(http://nerthus.margonem.pl/img/gui/cursor/5.png), url(http://nerthus.margonem.pl/img/gui/cursor/5.cur), pointer;
+    cursor: url(../img/gui/cursor/5.png), url(../img/gui/cursor/5.cur), pointer;
     height: 22px;
     padding: 0;
     pointer-events: auto;
     position: absolute;
     right: 3px;
-    top: 3px;
+    top: 2px;
     width: 22px;
 }
 
 #nerthus-panel .close-button:hover {
-    background-position: -286px -79px;
+    background-position-y: 0;
 }
 
 /* Panel - body */
@@ -167,7 +172,7 @@
     box-shadow: inset 0 0 1px 1px #cecece, inset 0 0 0 3px #0c0d0d;
     box-sizing: border-box;
     color: #E6D6BF;
-    cursor: url(http://nerthus.margonem.pl/img/gui/cursor/5.png), url(http://nerthus.margonem.pl/img/gui/cursor/5.cur), pointer;
+    cursor: url(../img/gui/cursor/5.png), url(../img/gui/cursor/5.cur), pointer;
     display: inline-block;
     height: 42px;
     line-height: 34px;
@@ -287,7 +292,7 @@
 }
 
 #nerthus-panel .setting-label-text {
-    cursor: url(http://nerthus.margonem.pl/img/gui/cursor/5.png), url(http://nerthus.margonem.pl/img/gui/cursor/5.cur), pointer;;
+    cursor: url(../img/gui/cursor/5.png), url(../img/gui/cursor/5.cur), pointer;;
     left: 25px;
     line-height: 28px;
     position: relative;
@@ -301,7 +306,7 @@
     border: 2px solid #6e644b;
     border-radius: 2px;
     box-sizing: border-box;
-    cursor: url(http://nerthus.margonem.pl/img/gui/cursor/5.png), url(http://nerthus.margonem.pl/img/gui/cursor/5.cur), pointer;;
+    cursor: url(../img/gui/cursor/5.png), url(../img/gui/cursor/5.cur), pointer;;
     display: inline-block;
     height: 18px;
     left: 0;


### PR DESCRIPTION
You can no longer get NI images while having `interface=si` cookie, so we're using duckduckgo images to get images without any cookies.